### PR TITLE
Bug on temporalCalendarField

### DIFF
--- a/community/src/test/java/org/batoo/jpa/community/test/calendarTemporalField/CalendarTemporalFieldEntity.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/calendarTemporalField/CalendarTemporalFieldEntity.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012 - Batoo Software ve Consultancy Ltd.
+ * 
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.batoo.jpa.community.test.calendarTemporalField;
+
+import java.util.Calendar;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+@Entity
+@Table
+@SuppressWarnings("javadoc")
+public class CalendarTemporalFieldEntity {
+	@Id
+	@Column(name = "ID", nullable = false)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	protected Long id = null;
+
+	@Basic
+	@Temporal(TemporalType.TIMESTAMP)
+	private Calendar date;
+
+	public CalendarTemporalFieldEntity() {
+		super();
+	}
+	
+	public Long getId() {
+		return id;
+	}
+	
+	public void setDate(Calendar date) {
+		this.date = date;
+	}
+	
+	public Calendar getDate() {
+		return date;
+	}
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/calendarTemporalField/TestCalendarTemporalField.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/calendarTemporalField/TestCalendarTemporalField.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2012 - Batoo Software ve Consultancy Ltd.
+ * 
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.batoo.jpa.community.test.calendarTemporalField;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Calendar;
+
+import org.batoo.jpa.community.test.BaseCoreTest;
+import org.batoo.jpa.community.test.NoDatasource;
+import org.junit.Test;
+
+/**
+ * Test for the issue calendarTemporalField
+ * 
+ * @author ylemoigne
+ * @since $version
+ */
+@SuppressWarnings("javadoc")
+public class TestCalendarTemporalField extends BaseCoreTest {
+	@Test
+	@NoDatasource
+	public void test() {
+		Calendar testStartInstant = Calendar.getInstance();
+		
+		final CalendarTemporalFieldEntity mainEntity = new CalendarTemporalFieldEntity();
+		mainEntity.setDate(testStartInstant);
+		persist(mainEntity);
+		this.commit();
+
+		this.close();
+
+		final CalendarTemporalFieldEntity mainEntityReloaded = find(CalendarTemporalFieldEntity.class, mainEntity.getId());
+		assertEquals(mainEntity.getId(), mainEntityReloaded.getId());
+		assertEquals(testStartInstant, mainEntityReloaded.getDate());
+	}
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/calendarTemporalField/persistence.xml
+++ b/community/src/test/java/org/batoo/jpa/community/test/calendarTemporalField/persistence.xml
@@ -1,0 +1,41 @@
+<!-- 
+
+	Copyright (c) 2012 - Batoo Software ve Consultancy Ltd.
+ 
+	This copyrighted material is made available to anyone wishing to use, modify,
+	copy, or redistribute it subject to the terms and conditions of the GNU
+	Lesser General Public License, as published by the Free Software Foundation.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+	or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+	for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this distribution; if not, write to:
+	Free Software Foundation, Inc.
+	51 Franklin Street, Fifth Floor
+	Boston, MA  02110-1301  USA
+
+ -->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+	version="2.0">
+
+	<persistence-unit name="default">
+		<provider>org.batoo.jpa.core.BatooPersistenceProvider</provider>
+		
+		<class>org.batoo.jpa.community.test.calendarTemporalField.CalendarTemporalFieldEntity</class>
+						
+		<exclude-unlisted-classes>true</exclude-unlisted-classes>		
+		<properties>
+			<property name="org.batoo.jpa.ddl" value="DROP" />
+ 			<property name="javax.persistence.jdbc.driver" value="org.apache.derby.jdbc.Driver40"/>		
+			<property name="javax.persistence.jdbc.url" value="jdbc:derby:memory:test;create=true"/>
+			<property name="javax.persistence.jdbc.user" value="root"/>
+			<property name="javax.persistence.jdbc.password" value=""/>
+		</properties>
+
+	</persistence-unit>
+</persistence>


### PR DESCRIPTION
See JPA 11.1.47

There is an issue but I failed to reproduce the one it happend on my production app which was :

```
java.lang.RuntimeException: Cannot set field value: private java.util.Calendar xx.xx.xx.BusinessEntity.dateStart
    at org.batoo.common.reflect.FieldAccessor.set(FieldAccessor.java:187)
    at org.batoo.jpa.core.impl.model.attribute.AttributeImpl.set(AttributeImpl.java:209)
    at org.batoo.jpa.core.impl.model.mapping.AbstractMapping.set(AbstractMapping.java:233)
    at org.batoo.jpa.jdbc.BasicColumn.setValue(BasicColumn.java:253)
    at org.batoo.jpa.core.impl.criteria.join.FetchParentImpl.initializeInstance(FetchParentImpl.java:1013)
    at org.batoo.jpa.core.impl.criteria.join.FetchParentImpl.getInstance(FetchParentImpl.java:655)
    at org.batoo.jpa.core.impl.criteria.join.FetchParentImpl.handleFetch(FetchParentImpl.java:937)
    at org.batoo.jpa.core.impl.criteria.join.FetchParentImpl.handle(FetchParentImpl.java:803)
    at org.batoo.jpa.core.impl.criteria.join.FetchParentImpl.handle(FetchParentImpl.java:784)
    at org.batoo.jpa.core.impl.criteria.join.AbstractFrom.handle(AbstractFrom.java:395)
    at org.batoo.jpa.core.impl.criteria.QueryImpl.handle(QueryImpl.java:816)
    at org.batoo.jpa.core.impl.criteria.QueryImpl.buildResultSetImpl(QueryImpl.java:323)
    at org.batoo.jpa.core.impl.criteria.QueryImpl.buildResultSet(QueryImpl.java:263)
    at org.batoo.jpa.core.impl.criteria.QueryImpl.getResultListImpl(QueryImpl.java:762)
    at org.batoo.jpa.core.impl.criteria.QueryImpl.getResultList(QueryImpl.java:741)
    at org.batoo.jpa.core.impl.criteria.QueryImpl.getSingleResult(QueryImpl.java:777)
```
