### PR TITLE
Demonstrate bug : UnsupportedOperationException

### DIFF
--- a/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/EntityA.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/EntityA.java
@@ -1,0 +1,53 @@
+package org.batoo.jpa.community.test.unsupportedOperationException;
+
+import java.util.Map;
+
+import javax.persistence.CascadeType;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapKeyColumn;
+import javax.persistence.MapKeyEnumerated;
+
+@Entity
+public class EntityA {
+	@Id
+	@Column(name = "ID", nullable = false)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private final Long id = null;
+	
+	@ManyToOne(fetch = FetchType.LAZY, cascade = { CascadeType.REFRESH, CascadeType.PERSIST, CascadeType.MERGE }, targetEntity = EntityB.class)
+	@JoinColumn(name = "ID_ENTITYB", referencedColumnName = "ID")
+	private EntityB entityB;
+	
+	@ElementCollection(fetch = FetchType.EAGER)
+	@CollectionTable(name = "ENTITYA_NAME", joinColumns = @JoinColumn(name = "ID"))
+	@MapKeyEnumerated(EnumType.STRING)
+	@MapKeyColumn(name = "LOCALE", nullable = false)
+	@Column(name = "TRANSLATION", nullable = false)
+	private Map<FieldLocale, String> name;
+	
+	public void setEntityB(EntityB entityB) {
+		this.entityB = entityB;
+	}
+	
+	public EntityB getEntityB() {
+		return entityB;
+	}
+	
+	public void setName(Map<FieldLocale, String> name) {
+		this.name = name;
+	}
+	
+	public Map<FieldLocale, String> getName() {
+		return name;
+	}
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/EntityA_.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/EntityA_.java
@@ -1,0 +1,11 @@
+package org.batoo.jpa.community.test.unsupportedOperationException;
+
+import javax.persistence.metamodel.MapAttribute;
+import javax.persistence.metamodel.SingularAttribute;
+
+@javax.persistence.metamodel.StaticMetamodel(value = EntityA.class)
+public class EntityA_ {
+	public static volatile SingularAttribute<EntityA, Long> id;
+	public static volatile SingularAttribute<EntityA, EntityB> entityB;
+	public static volatile MapAttribute<EntityA, FieldLocale, String> name;
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/EntityB.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/EntityB.java
@@ -1,0 +1,44 @@
+package org.batoo.jpa.community.test.unsupportedOperationException;
+
+import java.util.Set;
+
+import javax.persistence.Basic;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+@Entity
+public class EntityB {
+	@Id
+	@Column(name = "ID", nullable = false)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private final Long id = null;
+	
+	@OneToMany(fetch = FetchType.LAZY, cascade = { CascadeType.REFRESH, CascadeType.PERSIST, CascadeType.MERGE }, targetEntity = EntityA.class, mappedBy = "entityB")
+	private Set<EntityA> entitiesA;
+
+	@Basic
+	@Column(name = "CODE", nullable = false)
+	private String code;
+	
+	public String getCode() {
+		return code;
+	}
+	
+	public void setCode(String code) {
+		this.code = code;
+	}
+	
+	public Set<EntityA> getEntitiesA() {
+		return entitiesA;
+	}
+	
+	public void setEntitiesA(Set<EntityA> entitiesA) {
+		this.entitiesA = entitiesA;
+	}
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/EntityB_.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/EntityB_.java
@@ -1,0 +1,11 @@
+package org.batoo.jpa.community.test.unsupportedOperationException;
+
+import javax.persistence.metamodel.SetAttribute;
+import javax.persistence.metamodel.SingularAttribute;
+
+@javax.persistence.metamodel.StaticMetamodel(value = EntityB.class)
+public class EntityB_  {
+	public static volatile SingularAttribute<EntityB, Long> id;
+	public static volatile SingularAttribute<EntityB, String> code;
+	public static volatile SetAttribute<EntityB, EntityA> entitiesA;
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/FieldLocale.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/FieldLocale.java
@@ -1,0 +1,5 @@
+package org.batoo.jpa.community.test.unsupportedOperationException;
+
+public enum FieldLocale {
+	fr, tr, gb;
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/TestUnsupportedOperationException.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/TestUnsupportedOperationException.java
@@ -1,0 +1,53 @@
+package org.batoo.jpa.community.test.unsupportedOperationException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
+
+import org.batoo.jpa.community.test.BaseCoreTest;
+import org.batoo.jpa.community.test.NoDatasource;
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+
+public class TestUnsupportedOperationException extends BaseCoreTest{
+	@Test
+	@NoDatasource
+	public void test(){
+		Map<FieldLocale, String> translationMap = new HashMap<FieldLocale, String>();
+		translationMap.put(FieldLocale.fr, "Bonjour Asim !");
+		translationMap.put(FieldLocale.gb, "Hello Asim !");
+		translationMap.put(FieldLocale.tr, "Merhaba Asim !");
+		
+		EntityA entityAPrime = new EntityA();
+		entityAPrime.setName(translationMap);
+		EntityA entityASecond = new EntityA();
+		entityASecond.setName(translationMap);
+		EntityA entityAThird = new EntityA();
+		entityAThird.setName(translationMap);
+		
+		EntityB entityBFoo = new EntityB();
+		entityBFoo.setCode("foo");
+		entityBFoo.setEntitiesA(Sets.newHashSet(entityAPrime, entityASecond, entityAThird));
+		
+		entityAPrime.setEntityB(entityBFoo);
+		entityASecond.setEntityB(entityBFoo);
+		entityAThird.setEntityB(entityBFoo);
+		
+		this.begin();
+		persist(entityBFoo);
+		this.commit();
+		this.close();
+		em().clear();
+		
+		CriteriaBuilder qBuilder = em().getCriteriaBuilder();
+		CriteriaQuery<EntityA> query = qBuilder.createQuery(EntityA.class);
+		Join<EntityA, EntityB> join = query.from(EntityA.class).join(EntityA_.entityB);
+		query.where(qBuilder.equal(join.get(EntityB_.code), "foo"));
+
+		em().createQuery(query).getResultList();
+	}
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/persistence.xml
+++ b/community/src/test/java/org/batoo/jpa/community/test/unsupportedOperationException/persistence.xml
@@ -1,0 +1,42 @@
+<!-- 
+
+	Copyright (c) 2012 - Batoo Software ve Consultancy Ltd.
+ 
+	This copyrighted material is made available to anyone wishing to use, modify,
+	copy, or redistribute it subject to the terms and conditions of the GNU
+	Lesser General Public License, as published by the Free Software Foundation.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+	or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+	for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this distribution; if not, write to:
+	Free Software Foundation, Inc.
+	51 Franklin Street, Fifth Floor
+	Boston, MA  02110-1301  USA
+
+ -->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+	version="2.0">
+
+	<persistence-unit name="default">
+		<provider>org.batoo.jpa.core.BatooPersistenceProvider</provider>
+		
+		<class>org.batoo.jpa.community.test.unsupportedOperationException.EntityA</class>
+		<class>org.batoo.jpa.community.test.unsupportedOperationException.EntityB</class>
+						
+		<exclude-unlisted-classes>true</exclude-unlisted-classes>		
+		<properties>
+			<property name="org.batoo.jpa.ddl" value="DROP" />
+ 			<property name="javax.persistence.jdbc.driver" value="org.apache.derby.jdbc.Driver40"/>		
+			<property name="javax.persistence.jdbc.url" value="jdbc:derby:memory:test;create=true"/>
+			<property name="javax.persistence.jdbc.user" value="root"/>
+			<property name="javax.persistence.jdbc.password" value=""/>
+		</properties>
+
+	</persistence-unit>
+</persistence>


### PR DESCRIPTION
Demonstrate bug : UnsupportedOperationException

'''
Caused by: java.lang.UnsupportedOperationException
    at java.util.AbstractCollection.add(Unknown Source) [rt.jar:1.7.0_15]
    at org.batoo.common.util.BatooUtils.addAll(BatooUtils.java:77) [batoo-jpa-2.0.1.0-SNAPSHOT.jar:]
    at org.batoo.jpa.core.impl.model.mapping.ElementCollectionMappingImpl.setCollection(ElementCollectionMappingImpl.java:564) [batoo-jpa-2.0.1.0-SNAPSHOT.jar:]
    at org.batoo.jpa.core.impl.model.mapping.ElementCollectionMappingImpl.load(ElementCollectionMappingImpl.java:517) [batoo-jpa-2.0.1.0-SNAPSHOT.jar:]
    at org.batoo.jpa.core.impl.instance.ManagedInstance.processJoinedMappings(ManagedInstance.java:897) [batoo-jpa-2.0.1.0-SNAPSHOT.jar:]
    at org.batoo.jpa.core.impl.manager.SessionImpl.releaseLoadTracker(SessionImpl.java:640) [batoo-jpa-2.0.1.0-SNAPSHOT.jar:]
    at org.batoo.jpa.core.impl.criteria.QueryImpl.getResultListImpl(QueryImpl.java:765) [batoo-jpa-2.0.1.0-SNAPSHOT.jar:]
    at org.batoo.jpa.core.impl.criteria.QueryImpl.getResultList(QueryImpl.java:741) [batoo-jpa-2.0.1.0-SNAPSHOT.jar:]
    at org.batoo.jpa.core.impl.criteria.QueryImpl.getSingleResult(QueryImpl.java:777) [batoo-jpa-2.0.1.0-SNAPSHOT.jar:]'''
