### PR TITLE
Bug on abstract entity

### DIFF
--- a/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/AbstractEntity.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/AbstractEntity.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012 - Batoo Software ve Consultancy Ltd.
+ * 
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.batoo.jpa.community.test.abstractJigsaw;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.DiscriminatorType;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "CONCRETE_TYPE", discriminatorType = DiscriminatorType.STRING, length = 50)
+@Table(name = "AbstractEntity")
+@SuppressWarnings("javadoc")
+public abstract class AbstractEntity extends TopMappedSuperClass {
+	@Basic
+	@Column(nullable = false)
+	private String myAbstractProperty;
+
+	public AbstractEntity() {
+		super();
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public String getMyAbstractProperty() {
+		return this.myAbstractProperty;
+	}
+
+	abstract public String getMyConcreteProperty();
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setMyAbstractProperty(String myAbstractProperty) {
+		this.myAbstractProperty = myAbstractProperty;
+	}
+
+	@Override
+	public abstract AbstractEntityUnwrapper unwrapper();
+
+	public abstract static class AbstractEntityUnwrapper implements TopMappedSuperClass.IUnwrapper {
+		@Override
+		public abstract AbstractEntity unwrap();
+	}
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/ConcreteEntity.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/ConcreteEntity.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012 - Batoo Software ve Consultancy Ltd.
+ * 
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.batoo.jpa.community.test.abstractJigsaw;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Table
+@DiscriminatorValue("ConcreteEntity")
+@SuppressWarnings("javadoc")
+public class ConcreteEntity extends AbstractEntity {
+
+	@Basic
+	@Column(nullable = false)
+	private String myConcreteProperty;
+
+	public ConcreteEntity() {
+		super();
+	}
+
+	public ConcreteEntity(String myAbstractProperty, String myConcreteProperty) {
+		setMyAbstractProperty(myAbstractProperty);
+		this.myConcreteProperty = myConcreteProperty;
+	}
+
+	@Override
+	public String getMyConcreteProperty() {
+		return this.myConcreteProperty;
+	}
+	
+	public Unwrapper unwrapper() {
+		return new Unwrapper(this);
+	}
+
+	public static class Unwrapper extends AbstractEntity.AbstractEntityUnwrapper {
+		private ConcreteEntity _bo;
+
+		public Unwrapper(ConcreteEntity bo) {
+			_bo = bo;
+		}
+
+		@Override
+		public ConcreteEntity unwrap() {
+			return _bo;
+		}
+	}
+
+
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/EntityPointToAbstractEntity.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/EntityPointToAbstractEntity.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2012 - Batoo Software ve Consultancy Ltd.
+ * 
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.batoo.jpa.community.test.abstractJigsaw;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table
+@SuppressWarnings("javadoc")
+public class EntityPointToAbstractEntity {
+	@Id
+	@Column(name = "ID", nullable = false)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	protected Long id = null;
+
+	@ManyToOne(fetch = FetchType.EAGER, cascade = { CascadeType.REFRESH, CascadeType.PERSIST, CascadeType.MERGE }, targetEntity = AbstractEntity.class)
+	@JoinColumn(name = "ID_ABSTRACT_ENTITY", referencedColumnName = "ID", nullable = false)
+	private AbstractEntity abstractEntity;
+
+	public EntityPointToAbstractEntity() {
+		super();
+	}
+
+	public AbstractEntity getAbstractEntity() {
+		return this.abstractEntity;
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public void setAbstractEntity(AbstractEntity abstractEntity) {
+		this.abstractEntity = abstractEntity;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/TestAbstractJigsaw.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/TestAbstractJigsaw.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2012 - Batoo Software ve Consultancy Ltd.
+ * 
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.batoo.jpa.community.test.abstractJigsaw;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.batoo.jpa.community.test.BaseCoreTest;
+import org.batoo.jpa.community.test.NoDatasource;
+import org.junit.Test;
+
+/**
+ * Test for the issue abstractJigsaw
+ * 
+ * @author ylemoigne
+ * @since 2.0.1
+ */
+@SuppressWarnings("javadoc")
+public class TestAbstractJigsaw extends BaseCoreTest {
+	@Test
+	@NoDatasource
+	public void test() {
+		final ConcreteEntity entityA = new ConcreteEntity("plop", "foo");
+		persist(entityA);
+
+		final EntityPointToAbstractEntity mainEntity = new EntityPointToAbstractEntity();
+		mainEntity.setAbstractEntity(entityA);
+		persist(mainEntity);
+		this.commit();
+
+		this.close();
+
+		final EntityPointToAbstractEntity mainEntityReloaded = find(EntityPointToAbstractEntity.class, mainEntity.getId());
+		assertEquals(mainEntity.getId(), mainEntityReloaded.getId());
+		assertThat(mainEntityReloaded.getAbstractEntity().unwrapper().unwrap(), instanceOf(ConcreteEntity.class));
+	}
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/TopMappedSuperClass.java
+++ b/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/TopMappedSuperClass.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2012 - Batoo Software ve Consultancy Ltd.
+ * 
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.batoo.jpa.community.test.abstractJigsaw;
+
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.Version;
+
+@SuppressWarnings("javadoc")
+@MappedSuperclass
+public abstract class TopMappedSuperClass {
+
+	@Id
+	@Column(name = "ID", nullable = false)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	protected Long id = null;
+
+	@Version
+	@Column(nullable = false)
+	protected Long timeStamp = null;
+
+	public TopMappedSuperClass() {
+		super();
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public Long getTimeStamp() {
+		return this.timeStamp;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setTimeStamp(Long timeStamp) {
+		this.timeStamp = timeStamp;
+	}
+
+	public interface IUnwrapper {
+		TopMappedSuperClass unwrap();
+	};
+
+	public abstract IUnwrapper unwrapper();
+}

--- a/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/persistence.xml
+++ b/community/src/test/java/org/batoo/jpa/community/test/abstractJigsaw/persistence.xml
@@ -1,0 +1,44 @@
+<!-- 
+
+	Copyright (c) 2012 - Batoo Software ve Consultancy Ltd.
+ 
+	This copyrighted material is made available to anyone wishing to use, modify,
+	copy, or redistribute it subject to the terms and conditions of the GNU
+	Lesser General Public License, as published by the Free Software Foundation.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+	or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+	for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this distribution; if not, write to:
+	Free Software Foundation, Inc.
+	51 Franklin Street, Fifth Floor
+	Boston, MA  02110-1301  USA
+
+ -->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+	version="2.0">
+
+	<persistence-unit name="default">
+		<provider>org.batoo.jpa.core.BatooPersistenceProvider</provider>
+		
+		<class>org.batoo.jpa.community.test.abstractJigsaw.AbstractEntity</class>
+		<class>org.batoo.jpa.community.test.abstractJigsaw.ConcreteEntity</class>
+		<class>org.batoo.jpa.community.test.abstractJigsaw.TopMappedSuperClass</class>
+		<class>org.batoo.jpa.community.test.abstractJigsaw.EntityPointToAbstractEntity</class>
+						
+		<exclude-unlisted-classes>true</exclude-unlisted-classes>		
+		<properties>
+			<property name="org.batoo.jpa.ddl" value="DROP" />
+ 			<property name="javax.persistence.jdbc.driver" value="org.apache.derby.jdbc.Driver40"/>		
+			<property name="javax.persistence.jdbc.url" value="jdbc:derby:memory:test;create=true"/>
+			<property name="javax.persistence.jdbc.user" value="root"/>
+			<property name="javax.persistence.jdbc.password" value=""/>
+		</properties>
+
+	</persistence-unit>
+</persistence>


### PR DESCRIPTION
This one is a little tricky because the case is wicked.

To work around the "hibernate proxy breaks instanceof" problems while keeping lazy loading, we used the code which is in that testcase.

It's a trick based on the following fact :
- If a method exist in lower classes in the hierarchy, hibernate must unproxy the instance to allow method execution.
- If a method return the same instance of the method on which we execute the method, hibernate proxy return the proxy rather than the 'this' of the method.

So, by calling unwrapper() on the instance, we bind hibernate to unproxy the instance, by returning an instance of another object, it won't replace the return result by another thing.

Then we can call unwrap() to get the unwrapped instance of the object. 
