### PR TITLE
Honor targetEntity on OneToOne and OneToMany

### DIFF
--- a/batoo-jpa/src/main/java/org/batoo/jpa/core/impl/model/mapping/SingularAssociationMappingImpl.java
+++ b/batoo-jpa/src/main/java/org/batoo/jpa/core/impl/model/mapping/SingularAssociationMappingImpl.java
@@ -297,7 +297,7 @@ public class SingularAssociationMappingImpl<Z, X> extends AssociationMappingImpl
 	@Override
 	public void link() throws MappingException {
 		final MetamodelImpl metamodel = this.getAttribute().getMetamodel();
-		this.type = metamodel.entity(this.attribute.getJavaType());
+		this.type = metamodel.entity(this.attribute.getBindableJavaType());
 
 		if (!this.isOwner()) {
 			this.inverse = (AssociationMappingImpl<?, ?, ?>) this.type.getRootMapping().getMapping(this.getMappedBy());


### PR DESCRIPTION
Allows the targetEntity annotation attribute to be honored when specified in an appropriate SingularAttribute (ie OneToOne and OneToMany).

This is my first time using Git and GitHub so I apologize in advance if I've messed up the procedure in some way...
