### PR TITLE
AbstractMapping now considers BindableType attributes

### DIFF
--- a/batoo-jpa/src/main/java/org/batoo/jpa/core/impl/model/mapping/AbstractMapping.java
+++ b/batoo-jpa/src/main/java/org/batoo/jpa/core/impl/model/mapping/AbstractMapping.java
@@ -20,6 +20,8 @@ package org.batoo.jpa.core.impl.model.mapping;
 
 import java.lang.reflect.Member;
 
+import javax.persistence.metamodel.Bindable;
+
 import org.batoo.jpa.core.impl.model.EntityTypeImpl;
 import org.batoo.jpa.core.impl.model.MetamodelImpl;
 import org.batoo.jpa.core.impl.model.attribute.AttributeImpl;
@@ -67,7 +69,7 @@ public abstract class AbstractMapping<Z, X, Y> implements Mapping<Z, X, Y> {
 	public AbstractMapping(AbstractParentMapping<?, Z> parent, AttributeImpl<? super Z, X> attribute, Class<X> javaType, String name) {
 		super();
 
-		this.javaType = javaType;
+		this.javaType = attribute instanceof Bindable ? ((Bindable) attribute).getBindableJavaType() : javaType;
 		this.parent = parent;
 		this.attribute = attribute;
 		this.name = name;

--- a/batoo-jpa/src/main/java/org/batoo/jpa/core/impl/model/mapping/AssociationMappingImpl.java
+++ b/batoo-jpa/src/main/java/org/batoo/jpa/core/impl/model/mapping/AssociationMappingImpl.java
@@ -397,7 +397,7 @@ public abstract class AssociationMappingImpl<Z, X, Y> extends AbstractMapping<Z,
 
 			final EntityTypeImpl<Y> entity = metamodel.entity(bindableType);
 
-			this.ownerSelect = this.isOwner() || isOwnerSelectType();
+			this.ownerSelect = this.isOwner() || PersistentAttributeType.MANY_TO_MANY == getAttribute().getPersistentAttributeType();
 			if (this.ownerSelect) {
 				return this.generateOwnerSelectCriteria(metamodel, cb, bindableType, entity);
 			}
@@ -457,12 +457,6 @@ public abstract class AssociationMappingImpl<Z, X, Y> extends AbstractMapping<Z,
 	 */
 	protected boolean isOwnerSelect() {
 		return this.ownerSelect;
-	}
-
-	protected boolean isOwnerSelectType() {
-		final PersistentAttributeType pat = getAttribute().getPersistentAttributeType();
-
-		return pat == PersistentAttributeType.MANY_TO_MANY || pat == PersistentAttributeType.ONE_TO_MANY;
 	}
 
 	/**


### PR DESCRIPTION
Uncovered AbstractMapping was not using the BindableType which was causing issues resolving mapping types when the actual java type was an interface but the target entity was specified appropriately in metadata/annotations.

Without AbstractMapping aware of the BindableType entity parameters were being set as an object stream value instead of their primary key. The issue was originating out of AssociationMappingImpl.generateMappedSelectCriteria (call to getInverse().getJavaType() was incorrectly returning the member interface instead of the entity implementation defined via targetEntity) but this improved handling should be beneficial throughout.

The previous owner select override (previous commit in this branch) turned out to be a cover up and accidentally forced all OneToMany mappings to have a bidirectional relationship.
