### PR TITLE
Make BatooJPA OSGi friendly (fix ASM Version Ranges) 

### DIFF
--- a/batoo-jpa/pom.xml
+++ b/batoo-jpa/pom.xml
@@ -101,7 +101,7 @@
 						</Export-Package>
 						<Import-Package>
 							com.jolbox.bonecp;resolution:=optional,
-							org.objectweb.asm.*;version=3.3,
+							org.objectweb.asm.*;version="[3.3,4)",
 							!org.batoo.*,
 							!sun.*,
 							*


### PR DESCRIPTION
BatooJPA now imports 3.3 <= ObjectWeb's ASM < 4
